### PR TITLE
new - pass address from config into node-lifx app

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@
 //         "resendPacketDelay": 150,         // optional: delay between packages if light did not receive a packet (for setting methods with callback)
 //         "resendMaxTimes": 3,              // optional: resend packages x times if light did not receive a packet (for setting methods with callback)
 //         "debug": false                    // optional: logs all messages in console if turned on
+//         "address": '0.0.0.0'              // optional: specify which ipv4 address to bind to
 //     }
 // ],
 //
@@ -125,7 +126,8 @@ class LifxLanPlatform {
                 lightOfflineTolerance:  this.config.lightOfflineTolerance || 5,
                 messageHandlerTimeout:  this.config.messageHandlerTimeout || 45000,
                 resendMaxTimes:         this.config.resendMaxTimes || 4,
-                resendPacketDelay:      this.config.resendPacketDelay || 150
+                resendPacketDelay:      this.config.resendPacketDelay || 150,
+                address:                this.config.address || '0.0.0.0'
             });
         }.bind(this));
     }


### PR DESCRIPTION
This allows multiple different clients to listen on specific ipv4 addresses, allowing different processes to control the lifx bulbs.